### PR TITLE
Simplify installation process on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     {
       "name": "René Viering",
       "email": "rene.viering@gmail.com"
+    },
+    {
+      "name": "Henning Storck",
+      "email": "henning.storck@outlook.de"
     }
   ],
   "dependencies": {

--- a/src/components/Brand.less
+++ b/src/components/Brand.less
@@ -67,7 +67,7 @@
 @media only screen and (max-width : 768px) {
   .wk-brand {
     flex: 0 0 40vh;
-    width: 100vw;
+    width: 100%;
     height: 40vh;
 
     .wk-logo {

--- a/src/components/Feed.less
+++ b/src/components/Feed.less
@@ -17,7 +17,6 @@
     -webkit-overflow-scrolling: touch;
 
     .wk-feed__item {
-      width: 37.5vw;
       padding: 20px 0 22px 0;
       margin: 0;
       border-bottom: 1px solid rgba(255,255,255, 0.1);
@@ -54,7 +53,7 @@
   .wk-feed {
     overflow: visible;
     flex: 1 1 auto;
-    width: 100vw;
+    width: 100%;
     display: block;
 
     .wk-bar:first-child {
@@ -69,7 +68,6 @@
       .wk-feed__item {
         padding: 0;
         margin: @grid-size/2 0;
-        width: 100vw;
 
         .wk-feed__item__title {
           padding: @grid-size @grid-size 0 @grid-size;

--- a/src/docs/1.2.0/getting-started/installing-wolkenkit/installing-on-windows/index.md
+++ b/src/docs/1.2.0/getting-started/installing-wolkenkit/installing-on-windows/index.md
@@ -4,12 +4,12 @@ To run wolkenkit on Windows you need to setup a few things.
 
 ## Preparing the system for Hyper-V
 
-As wolkenkit uses Linux-based Docker images, you have to use Hyper-V and Docker Machine to run wolkenkit. Currently, wolkenkit does not support native Windows images.
+As wolkenkit uses Linux-based Docker images, you have to use Hyper-V to run wolkenkit. Currently, wolkenkit does not support native Windows images.
 
 :::hint-warning
 > **Hyper-V support is experimental**
 >
-> Running wolkenkit on Windows using Hyper-V and Docker Machine is experimental, and not yet officially supported.
+> Running wolkenkit on Windows using Hyper-V is experimental, and not yet officially supported.
 :::
 
 ### Using hardware
@@ -50,51 +50,9 @@ $ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 > Don't forget to restart Windows once the commands have been completed.
 :::
 
-### Setting up the network
-
-By default, Hyper-V virtual machines are not accessible from the outside. To change this you need to set up an external network switch. For details on how to do this, please [refer to the Docker documentation](https://docs.docker.com/machine/drivers/hyper-v/#2-set-up-a-new-external-network-switch-optional)
-
-:::hint-warning
-> **Restart Windows**
->
-> From time to time Windows has problems with its routing tables after creating a new network switch. Hence it is recommended to restart Windows.
-:::
-
 ## Setting up Docker
 
 To run wolkenkit you need Docker <%= current.versions.docker %> or higher. To setup Docker on Windows, [download and install Docker for Windows](https://docs.docker.com/docker-for-windows/install/).
-
-### Creating a virtual machine
-
-Now you need to setup a virtual machine using Hyper-V and Docker Machine. Make sure to provide the name of the Hyper-V network switch that you created a few steps ago:
-
-```shell
-$ docker-machine create --driver hyperv --hyperv-virtual-switch "..." wolkenkit
-```
-
-### Setting up environment variables
-
-Finally, you need to setup the environment variables `DOCKER_HOST`, `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH`.
-
-For that, first run the following command to get the values for the environment variables:
-
-```shell
-$ docker-machine env --shell cmd wolkenkit
-```
-
-Then you have to set the environment variables using the appropriate values:
-
-```shell
-$ [Environment]::SetEnvironmentVariable("DOCKER_TLS_VERIFY", "1", "User")
-$ [Environment]::SetEnvironmentVariable("DOCKER_HOST", "...", "User")
-$ [Environment]::SetEnvironmentVariable("DOCKER_CERT_PATH", "...", "User")
-```
-
-:::hint-warning
-> **Restart PowerShell**
->
-> Since the environment variables are only available after a restart of the shell, now close and reopen PowerShell again, still using administrative privileges.
-:::
 
 ## Setting up Node.js
 
@@ -116,20 +74,6 @@ To download and install wolkenkit, run the following command:
 ```shell
 $ npm install -g wolkenkit@<%= current.versions.cli %>
 ```
-
-## Setting up local.wolkenkit.io
-
-When developing wolkenkit applications you will usually run them on the domain `local.wolkenkit.io`. This means that you need to set up this domain inside your `C:\Windows\System32\drivers\etc\hosts` file and make it point to the Docker server running on your previously created virtual machine. So, run the following command:
-
-```shell
-$ Add-Content C:\Windows\System32\drivers\etc\hosts "$(docker-machine ip wolkenkit)`tlocal.wolkenkit.io"
-```
-
-:::hint-warning
-> **Restart Windows**
->
-> Finally, restart Windows one last time.
-:::
 
 ## Verifying the installation
 

--- a/src/docs/latest/getting-started/installing-wolkenkit/installing-on-windows/index.md
+++ b/src/docs/latest/getting-started/installing-wolkenkit/installing-on-windows/index.md
@@ -4,12 +4,12 @@ To run wolkenkit on Windows you need to setup a few things.
 
 ## Preparing the system for Hyper-V
 
-As wolkenkit uses Linux-based Docker images, you have to use Hyper-V and Docker Machine to run wolkenkit. Currently, wolkenkit does not support native Windows images.
+As wolkenkit uses Linux-based Docker images, you have to use Hyper-V to run wolkenkit. Currently, wolkenkit does not support native Windows images.
 
 :::hint-warning
 > **Hyper-V support is experimental**
 >
-> Running wolkenkit on Windows using Hyper-V and Docker Machine is experimental, and not yet officially supported.
+> Running wolkenkit on Windows using Hyper-V is experimental, and not yet officially supported.
 :::
 
 ### Using hardware
@@ -50,51 +50,9 @@ $ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 > Don't forget to restart Windows once the commands have been completed.
 :::
 
-### Setting up the network
-
-By default, Hyper-V virtual machines are not accessible from the outside. To change this you need to set up an external network switch. For details on how to do this, please [refer to the Docker documentation](https://docs.docker.com/machine/drivers/hyper-v/#2-set-up-a-new-external-network-switch-optional)
-
-:::hint-warning
-> **Restart Windows**
->
-> From time to time Windows has problems with its routing tables after creating a new network switch. Hence it is recommended to restart Windows.
-:::
-
 ## Setting up Docker
 
 To run wolkenkit you need Docker <%= current.versions.docker %> or higher. To setup Docker on Windows, [download and install Docker for Windows](https://docs.docker.com/docker-for-windows/install/).
-
-### Creating a virtual machine
-
-Now you need to setup a virtual machine using Hyper-V and Docker Machine. Make sure to provide the name of the Hyper-V network switch that you created a few steps ago:
-
-```shell
-$ docker-machine create --driver hyperv --hyperv-virtual-switch "..." wolkenkit
-```
-
-### Setting up environment variables
-
-Finally, you need to setup the environment variables `DOCKER_HOST`, `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH`.
-
-For that, first run the following command to get the values for the environment variables:
-
-```shell
-$ docker-machine env --shell cmd wolkenkit
-```
-
-Then you have to set the environment variables using the appropriate values:
-
-```shell
-$ [Environment]::SetEnvironmentVariable("DOCKER_TLS_VERIFY", "1", "User")
-$ [Environment]::SetEnvironmentVariable("DOCKER_HOST", "...", "User")
-$ [Environment]::SetEnvironmentVariable("DOCKER_CERT_PATH", "...", "User")
-```
-
-:::hint-warning
-> **Restart PowerShell**
->
-> Since the environment variables are only available after a restart of the shell, now close and reopen PowerShell again, still using administrative privileges.
-:::
 
 ## Setting up Node.js
 
@@ -116,20 +74,6 @@ To download and install wolkenkit, run the following command:
 ```shell
 $ npm install -g wolkenkit@<%= current.versions.cli %>
 ```
-
-## Setting up local.wolkenkit.io
-
-When developing wolkenkit applications you will usually run them on the domain `local.wolkenkit.io`. This means that you need to set up this domain inside your `C:\Windows\System32\drivers\etc\hosts` file and make it point to the Docker server running on your previously created virtual machine. So, run the following command:
-
-```shell
-$ Add-Content C:\Windows\System32\drivers\etc\hosts "$(docker-machine ip wolkenkit)`tlocal.wolkenkit.io"
-```
-
-:::hint-warning
-> **Restart Windows**
->
-> Finally, restart Windows one last time.
-:::
 
 ## Verifying the installation
 


### PR DESCRIPTION
Wolkenkit doesn't need Docker Machine anymore to run on Windows systems. The sections related to the old setup with Docker Machine were deleted. The installation on Windows is now much easier.