### PR TITLE
Missing word in index.md

### DIFF
--- a/lib/docs/2.0.0/reference/creating-stateful-flows/reacting-to-state-transitions/index.md
+++ b/lib/docs/2.0.0/reference/creating-stateful-flows/reacting-to-state-transitions/index.md
@@ -18,7 +18,7 @@ const reactions = {
 };
 ```
 
-Some reactions require asynchronous code. Therefore, you can use the keywords `async` and `await`. To be able do this, define the reaction using the `async` keyword:
+Some reactions require asynchronous code. Therefore, you can use the keywords `async` and `await`. To be able to do this, define the reaction using the `async` keyword:
 
 ```javascript
 const reactions = {


### PR DESCRIPTION
"To be able do this, define the reaction using the `async` keyword" was missing the word "to".