### PR TITLE
Fix Reacting to state transitions example

### DIFF
--- a/lib/docs/3.0.0/reference/creating-stateful-flows/reacting-to-state-transitions/index.md
+++ b/lib/docs/3.0.0/reference/creating-stateful-flows/reacting-to-state-transitions/index.md
@@ -23,7 +23,7 @@ Some reactions require asynchronous code. Therefore, you can use the keywords `a
 ```javascript
 const reactions = {
   pristine: {
-    await 'awaiting-payment' (flow, event) {
+    async 'awaiting-payment' (flow, event) {
       // ...
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     {
       "name": "Radu Märza",
       "email": "radu.2010@gmx.de"
+    },
+    {
+      "name": "Max Tilford",
+      "email": "maxtilford@gmail.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Use `async` before the function definition, not `await`, which is used inside the function body.